### PR TITLE
Changes `entries` to decode the hash first

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,11 +43,11 @@
 
   // Run until we've processed the whole hash
   while(location.hash.length > 1 && !name) {
-    entries = location.hash.split('|');
+    entries = decodeURIComponent(location.hash).split('|');
     for(i = 0; i<entries.length; i++) {
       parts = entries[i].split('=');
-      name = decodeURIComponent(parts[0]);
-      value = decodeURIComponent(parts[1]);
+      name = parts[0];
+      value = parts[1];
       if(name == 'checksum') {
         checksum = value;
       }


### PR DESCRIPTION
- link with `|`s was turning into `%7C` if clicked directly (not copy-pasted)